### PR TITLE
Simplification in procedure to get Siesta code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
   - docker
 
 env:
-#  - DOCKER_COMPOSE_VERSION=1.10.0 COMPOSE_FOLDER=test-aiida-basic
-#  - DOCKER_COMPOSE_VERSION=1.10.0 COMPOSE_FOLDER=test-aiida-qepw
+  - DOCKER_COMPOSE_VERSION=1.10.0 COMPOSE_FOLDER=test-aiida-basic
+  - DOCKER_COMPOSE_VERSION=1.10.0 COMPOSE_FOLDER=test-aiida-qepw
   - DOCKER_COMPOSE_VERSION=1.10.0 COMPOSE_FOLDER=test-aiida-siesta
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,8 @@ services:
   - docker
 
 env:
-  - DOCKER_COMPOSE_VERSION=1.10.0 COMPOSE_FOLDER=test-aiida-basic
-  - DOCKER_COMPOSE_VERSION=1.10.0 COMPOSE_FOLDER=test-aiida-qepw
+#  - DOCKER_COMPOSE_VERSION=1.10.0 COMPOSE_FOLDER=test-aiida-basic
+#  - DOCKER_COMPOSE_VERSION=1.10.0 COMPOSE_FOLDER=test-aiida-qepw
   - DOCKER_COMPOSE_VERSION=1.10.0 COMPOSE_FOLDER=test-aiida-siesta
 
 before_install:

--- a/test-aiida-siesta/torquessh-withplugin/Dockerfile
+++ b/test-aiida-siesta/torquessh-withplugin/Dockerfile
@@ -7,9 +7,7 @@ CMD ["/sbin/my_init"]
 # Install required packages
 RUN apt-get update \ 
     && apt-get install -y --no-install-recommends \
-    bzr \
     gfortran \
-    liblapack-dev \
     liblapack-dev \
     make \
     && rm -rf /var/lib/apt/lists/* \
@@ -19,15 +17,20 @@ USER app
 
 WORKDIR /home/app
 
-RUN bzr branch https://code.launchpad.net/~albertog/siesta/4.0-aiida && \
-    cd 4.0-aiida/Obj/ && \
+#
+# Compile Siesta
+#
+RUN curl -L \
+    https://github.com/siesta-project/siesta-aiida-4.0/archive/master.tar.gz \
+     | tar xzf - && \
+    cd siesta-aiida-4.0-master/Obj/ && \
     sh ../Src/configure FC=gfortran && \
     sh ../Src/obj_setup.sh && \
     make && \
     mkdir /home/app/bin/ && \
     cp siesta /home/app/bin/siesta && \
     cd ../../ && \
-    rm -rf 4.0-aiida
+    rm -rf siesta-aiida-4.0-master
 
 # I need to go back to root
 USER root   

--- a/test-aiida-siesta/torquessh-withplugin/Dockerfile
+++ b/test-aiida-siesta/torquessh-withplugin/Dockerfile
@@ -20,9 +20,9 @@ WORKDIR /home/app
 #
 # Compile Siesta
 #
-RUN curl -L \
-    https://github.com/siesta-project/siesta-aiida-4.0/archive/master.tar.gz \
-     | tar xzf - && \
+RUN curl -L -o master.tar.gz \
+    https://github.com/siesta-project/siesta-aiida-4.0/archive/master.tar.gz && \
+    tar xzf master.tar.gz && \
     cd siesta-aiida-4.0-master/Obj/ && \
     sh ../Src/configure FC=gfortran && \
     sh ../Src/obj_setup.sh && \

--- a/test-aiida-siesta/torquessh-withplugin/Dockerfile
+++ b/test-aiida-siesta/torquessh-withplugin/Dockerfile
@@ -19,6 +19,9 @@ WORKDIR /home/app
 
 #
 # Compile Siesta
+#   Get source from a GitHub mirror of the Launchpad sources
+#   This avoids havingg to install bz and dependencies in the image
+#   (temporary hack)
 #
 RUN curl -L -o master.tar.gz \
     https://github.com/siesta-project/siesta-aiida-4.0/archive/master.tar.gz && \

--- a/test-aiida-siesta/torquessh-withplugin/Dockerfile
+++ b/test-aiida-siesta/torquessh-withplugin/Dockerfile
@@ -20,7 +20,7 @@ WORKDIR /home/app
 #
 # Compile Siesta
 #   Get source from a GitHub mirror of the Launchpad sources
-#   This avoids havingg to install bz and dependencies in the image
+#   This avoids having to install bzr and dependencies in the image
 #   (temporary hack)
 #
 RUN curl -L -o master.tar.gz \
@@ -33,7 +33,7 @@ RUN curl -L -o master.tar.gz \
     mkdir /home/app/bin/ && \
     cp siesta /home/app/bin/siesta && \
     cd ../../ && \
-    rm -rf siesta-aiida-4.0-master
+    rm -rf siesta-aiida-4.0-master master.tar.gz
 
 # I need to go back to root
 USER root   


### PR DESCRIPTION
By using a GitHub mirror, we can avoid installing bzr and dependencies in the images.