### PR TITLE
bump aiida version to 0.11.0

### DIFF
--- a/test-aiida-basic/aiida/Dockerfile
+++ b/test-aiida-basic/aiida/Dockerfile
@@ -1,6 +1,6 @@
 #TODO: specify a specific version here
 
-FROM aiidateam/aiida_core_base:0.10.0
+FROM aiidateam/aiida_core_base:0.11.0
 MAINTAINER AiiDA Team <info@aiida.net>
 
 # Make directory (if COPY in the line below creates it automatically, it then will

--- a/test-aiida-basic/aiida/scripts/core/computer-setup-input.txt
+++ b/test-aiida-basic/aiida/scripts/core/computer-setup-input.txt
@@ -4,6 +4,7 @@ torquessh
 True
 ssh
 torque
+#!/bin/bash
 /scratch/{username}/aiida_run
 mpirun -np {tot_num_mpiprocs}
 1

--- a/test-aiida-qepw/aiida/Dockerfile
+++ b/test-aiida-qepw/aiida/Dockerfile
@@ -1,6 +1,6 @@
 #TODO: specify a specific version here
 
-FROM aiidateam/aiida_core_base:0.10.0
+FROM aiidateam/aiida_core_base:0.11.0
 MAINTAINER AiiDA Team <info@aiida.net>
 
 # Make directory (if COPY in the line below creates it automatically, it then will

--- a/test-aiida-qepw/aiida/scripts/core/computer-setup-input.txt
+++ b/test-aiida-qepw/aiida/scripts/core/computer-setup-input.txt
@@ -4,6 +4,7 @@ torquessh
 True
 ssh
 torque
+#!/bin/bash
 /scratch/{username}/aiida_run
 mpirun -np {tot_num_mpiprocs}
 1


### PR DESCRIPTION
leaving 0.9.0 tests untouched for the moment...
I see that there were problems with moving these tests to 0.10.0 67acf3e9fbf38221ea1035339992422803136b10

If you know how to update them, feel free to commit to this PR (at some point they need to be - no point in keeping to test old aiida versions).