### PR TITLE
Volume mount fix

### DIFF
--- a/test-aiida-0.9.0-cp2k/aiida/Dockerfile
+++ b/test-aiida-0.9.0-cp2k/aiida/Dockerfile
@@ -13,12 +13,13 @@ COPY ./scripts/ /home/aiida/.dockerscripts/
 # Prepare the folders - the next command will assign it to the correct
 # user, so it works with proper permissions when I mount 
 # an external named volume
-RUN mkdir ~/.aiida/ && mkdir ~/.ssh/keys
+RUN mkdir ~/.aiida/ && mkdir ~/.ssh/keys && mkdir ~/.aiida_repo
 
 # Make  sure all things created have the right permissions
 USER root
 RUN chown -R aiida:aiida /home/aiida/.dockerscripts && \
     chown -R aiida:aiida /home/aiida/.aiida && \
+    chown -R aiida:aiida /home/aiida/.aiida_repo && \
     chown -R aiida:aiida /home/aiida/.ssh 
 
 # TO CHECK: also because we need to start the web service and install Apache

--- a/test-aiida-0.9.0-cp2k/docker-compose.yml
+++ b/test-aiida-0.9.0-cp2k/docker-compose.yml
@@ -28,7 +28,7 @@ services:
      build: aiida/
      volumes:
         - aiidalogs:/home/aiida/.aiida/
-        - aiidarepo:/home/aiida/.aiida-repo/
+        - aiidarepo:/home/aiida/.aiida_repo/
         - ./compose-init/sshkeys/sharedfolder:/home/aiida/.ssh/keys:ro
      depends_on:
         - db

--- a/test-aiida-0.9.0-cp2k/docker-compose.yml
+++ b/test-aiida-0.9.0-cp2k/docker-compose.yml
@@ -19,16 +19,16 @@ services:
   # torquessh-withplugin should extend torquessh_base
   # with your simulations software
   torquessh:
-     build: torquessh-withplugin/
+     build: ./torquessh-withplugin
      privileged: true
      env_file:
        - compose-init/env/torque.env
 
   aiida:
-     build: aiida/
+     build: ./aiida
      volumes:
-        - aiidalogs:/home/aiida/.aiida/
-        - aiidarepo:/home/aiida/.aiida_repo/
+        - aiidalogs:/home/aiida/.aiida
+        - aiidarepo:/home/aiida/.aiida_repo
         - ./compose-init/sshkeys/sharedfolder:/home/aiida/.ssh/keys:ro
      depends_on:
         - db

--- a/test-aiida-0.9.0-cp2k/docker-compose.yml
+++ b/test-aiida-0.9.0-cp2k/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   db:
      image: postgres:9.5
      volumes:
-       - dbdata:/var/lib/postgres/data
+       - dbdata:/var/lib/postgresql/data
      env_file:
        - compose-init/env/postgres.env
 

--- a/test-aiida-0.9.0-siesta/aiida/Dockerfile
+++ b/test-aiida-0.9.0-siesta/aiida/Dockerfile
@@ -13,12 +13,13 @@ COPY ./scripts/ /home/aiida/.dockerscripts/
 # Prepare the folders - the next command will assign it to the correct
 # user, so it works with proper permissions when I mount 
 # an external named volume
-RUN mkdir ~/.aiida/ && mkdir ~/.ssh/keys
+RUN mkdir ~/.aiida/ && mkdir ~/.ssh/keys && mkdir ~/.aiida_repo
 
 # Make  sure all things created have the right permissions
 USER root
 RUN chown -R aiida:aiida /home/aiida/.dockerscripts && \
     chown -R aiida:aiida /home/aiida/.aiida && \
+    chown -R aiida:aiida /home/aiida/.aiida_repo && \
     chown -R aiida:aiida /home/aiida/.ssh 
 
 # TO CHECK: also because we need to start the web service and install Apache

--- a/test-aiida-0.9.0-siesta/docker-compose.yml
+++ b/test-aiida-0.9.0-siesta/docker-compose.yml
@@ -28,7 +28,7 @@ services:
      build: aiida/
      volumes:
         - aiidalogs:/home/aiida/.aiida/
-        - aiidarepo:/home/aiida/.aiida-repo/
+        - aiidarepo:/home/aiida/.aiida_repo/
         - ./compose-init/sshkeys/sharedfolder:/home/aiida/.ssh/keys:ro
      depends_on:
         - db

--- a/test-aiida-0.9.0-siesta/docker-compose.yml
+++ b/test-aiida-0.9.0-siesta/docker-compose.yml
@@ -19,16 +19,16 @@ services:
   # torquessh-withplugin should extend torquessh_base
   # with your simulations software
   torquessh:
-     build: torquessh-withplugin/
+     build: ./torquessh-withplugin
      privileged: true
      env_file:
        - compose-init/env/torque.env
 
   aiida:
-     build: aiida/
+     build: ./aiida
      volumes:
-        - aiidalogs:/home/aiida/.aiida/
-        - aiidarepo:/home/aiida/.aiida_repo/
+        - aiidalogs:/home/aiida/.aiida
+        - aiidarepo:/home/aiida/.aiida_repo
         - ./compose-init/sshkeys/sharedfolder:/home/aiida/.ssh/keys:ro
      depends_on:
         - db

--- a/test-aiida-0.9.0-siesta/docker-compose.yml
+++ b/test-aiida-0.9.0-siesta/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   db:
      image: postgres:9.5
      volumes:
-       - dbdata:/var/lib/postgres/data
+       - dbdata:/var/lib/postgresql/data
      env_file:
        - compose-init/env/postgres.env
 

--- a/test-aiida-basic/aiida/Dockerfile
+++ b/test-aiida-basic/aiida/Dockerfile
@@ -13,12 +13,13 @@ COPY ./scripts/ /home/aiida/.dockerscripts/
 # Prepare the folders - the next command will assign it to the correct
 # user, so it works with proper permissions when I mount 
 # an external named volume
-RUN mkdir ~/.aiida/ && mkdir ~/.ssh/keys
+RUN mkdir ~/.aiida/ && mkdir ~/.ssh/keys && mkdir ~/.aiida_repo
 
 # Make  sure all things created have the right permissions
 USER root
 RUN chown -R aiida:aiida /home/aiida/.dockerscripts && \
     chown -R aiida:aiida /home/aiida/.aiida && \
+    chown -R aiida:aiida /home/aiida/.aiida_repo && \
     chown -R aiida:aiida /home/aiida/.ssh 
 
 # TO CHECK: also because we need to start the web service and install Apache

--- a/test-aiida-basic/docker-compose.yml
+++ b/test-aiida-basic/docker-compose.yml
@@ -19,16 +19,16 @@ services:
   # torquessh-quantumespresso is an example of 
   # how you can extend the base image
   torquessh:
-     build: torquessh-doubler/
+     build: ./torquessh-doubler
      privileged: true
      env_file:
        - compose-init/env/torque.env
 
   aiida:
-     build: aiida/
+     build: ./aiida
      volumes:
-        - aiidalogs:/home/aiida/.aiida/
-        - aiidarepo:/home/aiida/.aiida_repo/
+        - aiidalogs:/home/aiida/.aiida
+        - aiidarepo:/home/aiida/.aiida_repo
         - ./compose-init/sshkeys/sharedfolder:/home/aiida/.ssh/keys:ro
      depends_on:
         - db

--- a/test-aiida-basic/docker-compose.yml
+++ b/test-aiida-basic/docker-compose.yml
@@ -28,7 +28,7 @@ services:
      build: aiida/
      volumes:
         - aiidalogs:/home/aiida/.aiida/
-        - aiidarepo:/home/aiida/.aiida-repo/
+        - aiidarepo:/home/aiida/.aiida_repo/
         - ./compose-init/sshkeys/sharedfolder:/home/aiida/.ssh/keys:ro
      depends_on:
         - db

--- a/test-aiida-basic/docker-compose.yml
+++ b/test-aiida-basic/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   db:
      image: postgres:9.5
      volumes:
-       - dbdata:/var/lib/postgres/data
+       - dbdata:/var/lib/postgresql/data
      env_file:
        - compose-init/env/postgres.env
 

--- a/test-aiida-qepw/aiida/Dockerfile
+++ b/test-aiida-qepw/aiida/Dockerfile
@@ -13,7 +13,7 @@ COPY ./scripts/ /home/aiida/.dockerscripts/
 # Prepare the folders - the next command will assign it to the correct
 # user, so it works with proper permissions when I mount 
 # an external named volume
-RUN mkdir ~/.aiida/ && mkdir ~/.ssh/keys
+RUN mkdir ~/.aiida/ && mkdir ~/.ssh/keys && mkdir ~/.aiida_repo
 
 USER aiida
 WORKDIR /home/aiida/code
@@ -30,6 +30,7 @@ RUN git clone https://github.com/aiidateam/aiida-quantumespresso.git && \
 USER root
 RUN chown -R aiida:aiida /home/aiida/.dockerscripts && \
     chown -R aiida:aiida /home/aiida/.aiida && \
+    chown -R aiida:aiida /home/aiida/.aiida_repo && \
     chown -R aiida:aiida /home/aiida/.ssh 
 
 # TO CHECK: also because we need to start the web service and install Apache

--- a/test-aiida-qepw/docker-compose.yml
+++ b/test-aiida-qepw/docker-compose.yml
@@ -28,7 +28,7 @@ services:
      build: aiida/
      volumes:
         - aiidalogs:/home/aiida/.aiida/
-        - aiidarepo:/home/aiida/.aiida-repo/
+        - aiidarepo:/home/aiida/.aiida_repo/
         - ./compose-init/sshkeys/sharedfolder:/home/aiida/.ssh/keys:ro
      depends_on:
         - db

--- a/test-aiida-qepw/docker-compose.yml
+++ b/test-aiida-qepw/docker-compose.yml
@@ -19,16 +19,16 @@ services:
   # torquessh-withplugin should extend torquessh_base
   # with your simulations software
   torquessh:
-     build: torquessh-withplugin/
+     build: ./torquessh-withplugin
      privileged: true
      env_file:
        - compose-init/env/torque.env
 
   aiida:
-     build: aiida/
+     build: ./aiida
      volumes:
-        - aiidalogs:/home/aiida/.aiida/
-        - aiidarepo:/home/aiida/.aiida_repo/
+        - aiidalogs:/home/aiida/.aiida
+        - aiidarepo:/home/aiida/.aiida_repo
         - ./compose-init/sshkeys/sharedfolder:/home/aiida/.ssh/keys:ro
      depends_on:
         - db

--- a/test-aiida-qepw/docker-compose.yml
+++ b/test-aiida-qepw/docker-compose.yml
@@ -12,7 +12,7 @@ services:
   db:
      image: postgres:9.5
      volumes:
-       - dbdata:/var/lib/postgres/data
+       - dbdata:/var/lib/postgresql/data
      env_file:
        - compose-init/env/postgres.env
 


### PR DESCRIPTION
Correct volume mount point should be `/var/lib/postgresql/data` for database ([doc](https://hub.docker.com/_/postgres/)) and `/home/aiida/.aiida_repo` for file repository. Previous incorrectly mounted paths does not return error but data are written to the _container_ instead of mounted _volumes_. This results them not being persistent - the `startup_firsttime.sh` script has to be run every time after instead of a simple `docker-compose up`, which causes a long start-up time for testing on local machines.

Also reformatted paths in yml files - removed trailing `/` and added `./` for relative path. 